### PR TITLE
DOCS: index.rst basic text edits - use ref instead of links and move …

### DIFF
--- a/docs/source/general/timing/index.rst
+++ b/docs/source/general/timing/index.rst
@@ -17,4 +17,18 @@ BUT there are many components to getting good timing, and many ways that your ti
    detectingFrameDrops
    reducingFrameDrops
 
+Understand and measuring your timing
+---------------------------------------
+
+There are certain steps that we strongly advise you to take before running an experiment that needs to be temporally precise in PsychoPy, or indeed any other software:
+
+* Read `this timing megastudy <https://peerj.com/articles/9414/>`_ by Bridges et al (2020) which compares several pieces of behavioural software in terms of their temporal precision.
+* Check that your stimulus presentation monitor is not dropping frames. You can do this by running the timeByFrames.py demo. Find this demo in the `Coder` window > demos > timing. The timeByFrames demo examines the precision of your frame flips, and shows the results in a plot similar to the one below:
+
+.. figure:: /images/timeByFrameRes.png
+
+    The results here are for a 60Hz monitor, and you can see that there are no dropped frames from the left hand side of the screen, and also the timing of each frame is 16.7ms (shown on the right-hand side of the screen) which is what we would expect from a 60Hz monitor (1000ms/60 = 16.66ms).
+
+* Use a photodiode or other physical stimulus detector to fully understand the lag, and more importantly the variability of that lag, between any triggers that you send to indicate the start of your stimulus and when the stimulus actually starts.
+
 .. _Black Box Toolkit: https://www.blackboxtoolkit.com/

--- a/docs/source/hardware/index.rst
+++ b/docs/source/hardware/index.rst
@@ -8,28 +8,13 @@ PsychoPy is able to communicate with a range of external hardware, like EEG reco
 This page provides step-by-step instructions on how to communicate with some of the more commonly used hardware. The page is being updated regularly so if you don't see your device listed here please do post in the forum as we keep an eye on commonly-faced issues (and solutions!) there.
 
 
-Understand your timing
------------------------------
-
-It is essential to make timing very precise in your experiments, especially if you're looking to collect EEG data.
-There are certain steps that we strongly advise you to take before running an experiment that needs to be temporally precise in PsychoPy, or indeed any other software:
-
-* Read `this timing megastudy <https://peerj.com/articles/9414/>`_ by Bridges et al (2020) which compares several pieces of behavioural software in terms of their temporal precision.
-* Check that your stimulus presentation monitor is not dropping frames. You can do this by running the timeByFrames.py demo. Find this demo in the `Coder` window > demos > timing. The timeByFrames demo examines the precision of your frame flips, and shows the results in a plot similar to the one below:
-
-.. figure:: /images/timeByFrameRes.png
-
-    The results here are for a 60Hz monitor, and you can see that there are no dropped frames from the left hand side of the screen, and also the timing of each frame is 16.7ms (shown on the right-hand side of the screen) which is what we would expect from a 60Hz monitor (1000ms/60 = 16.66ms).
-
-* Use a photodiode or other physical stimulus detector to fully understand the lag, and more importantly the variability of that lag, between any triggers that you send to indicate the start of your stimulus and when the stimulus actually starts.
-
 Communicating with EEG
 -----------------------------
-Although these guides will talk you through how to communicate with EEG hardware, they can really be used to communicate with any device that is connected via the same method:
+Before getting started with an EEG study in PsychoPy, we **highly** recommend reading relevant information on how to measure and understand :ref:`timing`. Although these guides will talk you through how to communicate with EEG hardware, they can really be used to communicate with any device that is connected via the same method:
 
-- `Communicating via parallel port and USB <https://psychopy.org/hardware/parallelPortInstr.html>`_
-- `Communicating via serial port <https://psychopy.org/hardware/serialPortInstr.html>`_
-- `Communicating with EGI NetStation <https://psychopy.org/hardware/egiNetStation.html>`_
+- :ref:`parallel`
+- :ref:`serial`
+- :ref:`egi`
 -  `Communicating with Emotiv <https://www.psychopy.org/builder/components/emotiv_record.html>`_ please also see `this video tutorial <https://www.youtube.com/watch?v=rRoqGa4PoN8>`_.
 
 .. note::
@@ -38,11 +23,11 @@ Although these guides will talk you through how to communicate with EEG hardware
 Communicating with an eye-tracker
 ------------------------------------------
 
-- `Communicating with an eye-tracker using Builder components <https://psychopy.org/hardware/eyeTracking.html>`_
+- :ref:`eyetracking`
 
 
 Communicating with other devices
 ------------------------------------------
 
-- `Recording information from an Arduino microcontroller <https://psychopy.org/hardware/arduino.html>`_
+- :ref:`arduino`
 


### PR DESCRIPTION
…timing information to existing timing documentation (linked on this page now)

Moved timing information to existing docs on timing but added link to that page here. Used ref method instead of html method incase any folders are moved around in future. Otherwise I think this all looks good to go in!

